### PR TITLE
`sys.stdout.write()` だけだとバッファがフラッシュされないことがあるので、明示的にフラッシュするように修正

### DIFF
--- a/modules/base.py
+++ b/modules/base.py
@@ -118,6 +118,7 @@ class RemdisModule:
         sys.stdout.write('[%s] Body: %s, Update_type: %s, ID: %s\n'
                          % (iu['timestamp'], iu['body'],
                             iu['update_type'], iu['id']))
+        sys.stdout.flush()
 
     # YAML形式の設定ファイル読み込み関数
     def load_config(self, config_filename):


### PR DESCRIPTION
こんにちは。

README の [テキスト対話](https://github.com/remdis/remdis?tab=readme-ov-file#%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E5%AF%BE%E8%A9%B1) を試していたのですが、`tout.py` に結果がぜんぜん出てこない事象に遭遇しました。

ソースを読んだところ、`RemdisModule.printIU()` では `sys.stdout.write()` を使っているため、ここで出力がバッファリングされてそうだなと思ったので、[`sys.stdout.flush()`](https://docs.python.org/ja/3.5/library/io.html#io.IOBase.flush) を追加したところ、すぐ出力されるようになりました。

別の場所に追加すべきだったり、なにか他のルールがあったりするなら対応するので教えてもらえると嬉しいです。よろしくお願いします。