### PR TITLE
nnmnkwiiインストール時にエラーがでるため更新

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ mpmath==1.3.0
 msgpack==1.0.7
 multidict==6.0.5
 networkx==3.2.1
-nnmnkwii==0.1.2
+nnmnkwii==0.1.3
 numba==0.59.0
 numpy==1.26.4
 omegaconf==2.3.0


### PR DESCRIPTION
#### 概要
```
git clone https://github.com/remdis/remdis.git
cd remdis
conda create -n remdis python=3.11
conda activate remdis

pip3 install -r requirements.txt
```
pip3 install実行時にnnmnkwiiの箇所でエラーが発生いたしました。
nnmnkwiiのバージョンを==0.1.2から>=0.1.2に変更したところ0.1.3がインストールされ処理することができました。
中身等詳しく見れていないところ大変恐縮ですが、ご確認いただけますと幸いです。

#### 環境
- Windows 11
- Anaconda3
- Python@3.11.9(conda create -n remdis python=3.11でインストールしたもの)

#### log
```
Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Building wheels for collected packages: nnmnkwii
  Building wheel for nnmnkwii (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for nnmnkwii (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [258 lines of output]
      fatal: not a git repository (or any of the parent directories): .git
      <string>:57: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
      C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\dist.py:260: UserWarning: Unknown distribution option: 'tests_require'
        warnings.warn(msg)
      running bdist_wheel
      running build
      running build_py
      -- Building version 0.1.2
      creating build
      creating build\lib.win-amd64-cpython-311
      creating build\lib.win-amd64-cpython-311\nnmnkwii
      copying nnmnkwii\version.py -> build\lib.win-amd64-cpython-311\nnmnkwii
      copying nnmnkwii\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii
      creating build\lib.win-amd64-cpython-311\nnmnkwii\autograd
      copying nnmnkwii\autograd\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\autograd
      creating build\lib.win-amd64-cpython-311\nnmnkwii\baseline
      copying nnmnkwii\baseline\gmm.py -> build\lib.win-amd64-cpython-311\nnmnkwii\baseline
      copying nnmnkwii\baseline\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\baseline
      creating build\lib.win-amd64-cpython-311\nnmnkwii\datasets
      copying nnmnkwii\datasets\cmu_arctic.py -> build\lib.win-amd64-cpython-311\nnmnkwii\datasets
      copying nnmnkwii\datasets\jsut.py -> build\lib.win-amd64-cpython-311\nnmnkwii\datasets
      copying nnmnkwii\datasets\jvs.py -> build\lib.win-amd64-cpython-311\nnmnkwii\datasets
      copying nnmnkwii\datasets\ljspeech.py -> build\lib.win-amd64-cpython-311\nnmnkwii\datasets
      copying nnmnkwii\datasets\vcc2016.py -> build\lib.win-amd64-cpython-311\nnmnkwii\datasets
      copying nnmnkwii\datasets\vctk.py -> build\lib.win-amd64-cpython-311\nnmnkwii\datasets
      copying nnmnkwii\datasets\voice_statistics.py -> build\lib.win-amd64-cpython-311\nnmnkwii\datasets
      copying nnmnkwii\datasets\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\datasets
      creating build\lib.win-amd64-cpython-311\nnmnkwii\frontend
      copying nnmnkwii\frontend\merlin.py -> build\lib.win-amd64-cpython-311\nnmnkwii\frontend
      copying nnmnkwii\frontend\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\frontend
      creating build\lib.win-amd64-cpython-311\nnmnkwii\functions
      copying nnmnkwii\functions\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\functions
      creating build\lib.win-amd64-cpython-311\nnmnkwii\io
      copying nnmnkwii\io\hts.py -> build\lib.win-amd64-cpython-311\nnmnkwii\io
      copying nnmnkwii\io\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\io
      creating build\lib.win-amd64-cpython-311\nnmnkwii\metrics
      copying nnmnkwii\metrics\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\metrics
      creating build\lib.win-amd64-cpython-311\nnmnkwii\paramgen
      copying nnmnkwii\paramgen\_mlpg.py -> build\lib.win-amd64-cpython-311\nnmnkwii\paramgen
      copying nnmnkwii\paramgen\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\paramgen
      creating build\lib.win-amd64-cpython-311\nnmnkwii\postfilters
      copying nnmnkwii\postfilters\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\postfilters
      creating build\lib.win-amd64-cpython-311\nnmnkwii\preprocessing
      copying nnmnkwii\preprocessing\alignment.py -> build\lib.win-amd64-cpython-311\nnmnkwii\preprocessing
      copying nnmnkwii\preprocessing\f0.py -> build\lib.win-amd64-cpython-311\nnmnkwii\preprocessing
      copying nnmnkwii\preprocessing\generic.py -> build\lib.win-amd64-cpython-311\nnmnkwii\preprocessing
      copying nnmnkwii\preprocessing\modspec.py -> build\lib.win-amd64-cpython-311\nnmnkwii\preprocessing
      copying nnmnkwii\preprocessing\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\preprocessing
      creating build\lib.win-amd64-cpython-311\nnmnkwii\util
      copying nnmnkwii\util\files.py -> build\lib.win-amd64-cpython-311\nnmnkwii\util
      copying nnmnkwii\util\linalg.py -> build\lib.win-amd64-cpython-311\nnmnkwii\util
      copying nnmnkwii\util\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\util
      creating build\lib.win-amd64-cpython-311\nnmnkwii\autograd\_impl
      copying nnmnkwii\autograd\_impl\mlpg.py -> build\lib.win-amd64-cpython-311\nnmnkwii\autograd\_impl
      copying nnmnkwii\autograd\_impl\modspec.py -> build\lib.win-amd64-cpython-311\nnmnkwii\autograd\_impl
      copying nnmnkwii\autograd\_impl\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\autograd\_impl
      creating build\lib.win-amd64-cpython-311\nnmnkwii\paramgen\_bandmat
      copying nnmnkwii\paramgen\_bandmat\__init__.py -> build\lib.win-amd64-cpython-311\nnmnkwii\paramgen\_bandmat
      creating build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data
      copying nnmnkwii\util\_example_data\arctic_a0009.wav -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data
      copying nnmnkwii\util\_example_data\arctic_a0009_phone.lab -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data
      copying nnmnkwii\util\_example_data\arctic_a0009_state.lab -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data
      copying nnmnkwii\util\_example_data\COPYING -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data
      copying nnmnkwii\util\_example_data\questions-radio_dnn_416.hed -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data
      creating build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data
      creating build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\X_acoustic
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\X_acoustic\arctic_a0001.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\X_acoustic
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\X_acoustic\arctic_a0002.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\X_acoustic
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\X_acoustic\arctic_a0003.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\X_acoustic
      creating build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\X_duration
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\X_duration\arctic_a0001.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\X_duration
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\X_duration\arctic_a0002.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\X_duration
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\X_duration\arctic_a0003.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\X_duration
      creating build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_acoustic
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_acoustic\arctic_a0001.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_acoustic
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_acoustic\arctic_a0002.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_acoustic
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_acoustic\arctic_a0003.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_acoustic
      creating build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_duration
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_duration\arctic_a0001.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_duration
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_duration\arctic_a0002.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_duration
      copying nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_duration\arctic_a0003.npz -> build\lib.win-amd64-cpython-311\nnmnkwii\util\_example_data\slt_arctic_demo_data\Y_duration
      running build_ext
      Compiling nnmnkwii\util\_linalg.pyx because it changed.
      [1/1] Cythonizing nnmnkwii\util\_linalg.pyx
      building 'nnmnkwii.util._linalg' extension
      creating build\temp.win-amd64-cpython-311
      creating build\temp.win-amd64-cpython-311\Release
      creating build\temp.win-amd64-cpython-311\Release\nnmnkwii
      creating build\temp.win-amd64-cpython-311\Release\nnmnkwii\util
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -IC:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include -IC:\Users\hiden\anaconda3\envs\remdis\include -IC:\Users\hiden\anaconda3\envs\remdis\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt" /Tcnnmnkwii\util\_linalg.c /Fobuild\temp.win-amd64-cpython-311\Release\nnmnkwii\util\_linalg.obj -std=c99
      cl : Command line warning D9002 : ignoring unknown option '-std=c99'
      _linalg.c
      C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include\numpy\npy_1_7_deprecated_api.h(14) : Warning Msg: Using deprecated NumPy API, disable it with #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\link.exe" /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\libs /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\x64" /EXPORT:PyInit__linalg build\temp.win-amd64-cpython-311\Release\nnmnkwii\util\_linalg.obj /OUT:build\lib.win-amd64-cpython-311\nnmnkwii\util\_linalg.cp311-win_amd64.pyd /IMPLIB:build\temp.win-amd64-cpython-311\Release\nnmnkwii\util\_linalg.cp311-win_amd64.lib
         Creating library build\temp.win-amd64-cpython-311\Release\nnmnkwii\util\_linalg.cp311-win_amd64.lib and object build\temp.win-amd64-cpython-311\Release\nnmnkwii\util\_linalg.cp311-win_amd64.exp
      Generating code
      Finished generating code
      Compiling nnmnkwii\paramgen\mlpg_helper.pyx because it changed.
      [1/1] Cythonizing nnmnkwii\paramgen\mlpg_helper.pyx
      building 'nnmnkwii.paramgen.mlpg_helper' extension
      creating build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -IC:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include -IC:\Users\hiden\anaconda3\envs\remdis\include -IC:\Users\hiden\anaconda3\envs\remdis\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt" /Tcnnmnkwii\paramgen\mlpg_helper.c /Fobuild\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\mlpg_helper.obj -std=c99
      cl : Command line warning D9002 : ignoring unknown option '-std=c99'
      mlpg_helper.c
      C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include\numpy\npy_1_7_deprecated_api.h(14) : Warning Msg: Using deprecated NumPy API, disable it with #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\link.exe" /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\libs /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\x64" /EXPORT:PyInit_mlpg_helper build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\mlpg_helper.obj /OUT:build\lib.win-amd64-cpython-311\nnmnkwii\paramgen\mlpg_helper.cp311-win_amd64.pyd /IMPLIB:build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\mlpg_helper.cp311-win_amd64.lib
         Creating library build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\mlpg_helper.cp311-win_amd64.lib and object build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\mlpg_helper.cp311-win_amd64.exp
      Generating code
      Finished generating code
      Compiling nnmnkwii\paramgen\_bandmat\full.pyx because it changed.
      [1/1] Cythonizing nnmnkwii\paramgen\_bandmat\full.pyx
      building 'nnmnkwii.paramgen._bandmat.full' extension
      creating build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -IC:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include -IC:\Users\hiden\anaconda3\envs\remdis\include -IC:\Users\hiden\anaconda3\envs\remdis\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt" /Tcnnmnkwii\paramgen\_bandmat\full.c /Fobuild\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\full.obj -O3
      cl : Command line warning D9002 : ignoring unknown option '-O3'
      full.c
      C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include\numpy\npy_1_7_deprecated_api.h(14) : Warning Msg: Using deprecated NumPy API, disable it with #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
      nnmnkwii\paramgen\_bandmat\full.c(5119): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
      nnmnkwii\paramgen\_bandmat\full.c(5245): warning C4018: '<': signed/unsigned mismatch
      nnmnkwii\paramgen\_bandmat\full.c(5565): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
      nnmnkwii\paramgen\_bandmat\full.c(5667): warning C4018: '<': signed/unsigned mismatch
      nnmnkwii\paramgen\_bandmat\full.c(5677): warning C4018: '<': signed/unsigned mismatch
      nnmnkwii\paramgen\_bandmat\full.c(5976): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
      nnmnkwii\paramgen\_bandmat\full.c(6014): warning C4018: '<': signed/unsigned mismatch
      nnmnkwii\paramgen\_bandmat\full.c(6068): warning C4018: '<': signed/unsigned mismatch
      nnmnkwii\paramgen\_bandmat\full.c(6909): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
      nnmnkwii\paramgen\_bandmat\full.c(7081): warning C4018: '<': signed/unsigned mismatch
      nnmnkwii\paramgen\_bandmat\full.c(7091): warning C4018: '<': signed/unsigned mismatch
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\link.exe" /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\libs /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\x64" /EXPORT:PyInit_full build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\full.obj /OUT:build\lib.win-amd64-cpython-311\nnmnkwii\paramgen\_bandmat\full.cp311-win_amd64.pyd /IMPLIB:build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\full.cp311-win_amd64.lib
         Creating library build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\full.cp311-win_amd64.lib and object build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\full.cp311-win_amd64.exp
      Generating code
      Finished generating code
      Compiling nnmnkwii\paramgen\_bandmat\core.pyx because it changed.
      [1/1] Cythonizing nnmnkwii\paramgen\_bandmat\core.pyx
      building 'nnmnkwii.paramgen._bandmat.core' extension
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -IC:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include -IC:\Users\hiden\anaconda3\envs\remdis\include -IC:\Users\hiden\anaconda3\envs\remdis\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt" /Tcnnmnkwii\paramgen\_bandmat\core.c /Fobuild\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\core.obj -O3
      cl : Command line warning D9002 : ignoring unknown option '-O3'
      core.c
      C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include\numpy\npy_1_7_deprecated_api.h(14) : Warning Msg: Using deprecated NumPy API, disable it with #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
      nnmnkwii\paramgen\_bandmat\core.c(9099): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
      nnmnkwii\paramgen\_bandmat\core.c(9241): warning C4018: '<': signed/unsigned mismatch
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\link.exe" /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\libs /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\x64" /EXPORT:PyInit_core build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\core.obj /OUT:build\lib.win-amd64-cpython-311\nnmnkwii\paramgen\_bandmat\core.cp311-win_amd64.pyd /IMPLIB:build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\core.cp311-win_amd64.lib
         Creating library build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\core.cp311-win_amd64.lib and object build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\core.cp311-win_amd64.exp
      Generating code
      Finished generating code
      Compiling nnmnkwii\paramgen\_bandmat\tensor.pyx because it changed.
      [1/1] Cythonizing nnmnkwii\paramgen\_bandmat\tensor.pyx
      building 'nnmnkwii.paramgen._bandmat.tensor' extension
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -IC:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include -IC:\Users\hiden\anaconda3\envs\remdis\include -IC:\Users\hiden\anaconda3\envs\remdis\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt" /Tcnnmnkwii\paramgen\_bandmat\tensor.c /Fobuild\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\tensor.obj -O3
      cl : Command line warning D9002 : ignoring unknown option '-O3'
      tensor.c
      C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include\numpy\npy_1_7_deprecated_api.h(14) : Warning Msg: Using deprecated NumPy API, disable it with #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
      nnmnkwii\paramgen\_bandmat\tensor.c(5407): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
      nnmnkwii\paramgen\_bandmat\tensor.c(5522): warning C4018: '<': signed/unsigned mismatch
      nnmnkwii\paramgen\_bandmat\tensor.c(6541): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
      nnmnkwii\paramgen\_bandmat\tensor.c(6849): warning C4018: '<': signed/unsigned mismatch
      nnmnkwii\paramgen\_bandmat\tensor.c(8231): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
      nnmnkwii\paramgen\_bandmat\tensor.c(8346): warning C4018: '<': signed/unsigned mismatch
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\link.exe" /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\libs /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\x64" /EXPORT:PyInit_tensor build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\tensor.obj /OUT:build\lib.win-amd64-cpython-311\nnmnkwii\paramgen\_bandmat\tensor.cp311-win_amd64.pyd /IMPLIB:build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\tensor.cp311-win_amd64.lib
         Creating library build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\tensor.cp311-win_amd64.lib and object build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\tensor.cp311-win_amd64.exp
      Generating code
      Finished generating code
      Compiling nnmnkwii\paramgen\_bandmat\linalg.pyx because it changed.
      [1/1] Cythonizing nnmnkwii\paramgen\_bandmat\linalg.pyx
      building 'nnmnkwii.paramgen._bandmat.linalg' extension
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -IC:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include -IC:\Users\hiden\anaconda3\envs\remdis\include -IC:\Users\hiden\anaconda3\envs\remdis\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt" /Tcnnmnkwii\paramgen\_bandmat\linalg.c /Fobuild\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\linalg.obj -O3
      cl : Command line warning D9002 : ignoring unknown option '-O3'
      linalg.c
      C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\numpy\_core\include\numpy\npy_1_7_deprecated_api.h(14) : Warning Msg: Using deprecated NumPy API, disable it with #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
      nnmnkwii\paramgen\_bandmat\linalg.c(5546): warning C4244: '=': conversion from 'npy_intp' to 'unsigned long', possible loss of data
      nnmnkwii\paramgen\_bandmat\linalg.c(5574): warning C4244: '=': conversion from 'npy_intp' to 'unsigned long', possible loss of data
      nnmnkwii\paramgen\_bandmat\linalg.c(6561): warning C4244: '=': conversion from 'npy_intp' to 'unsigned long', possible loss of data
      nnmnkwii\paramgen\_bandmat\linalg.c(6589): warning C4244: '=': conversion from 'npy_intp' to 'unsigned long', possible loss of data
      nnmnkwii\paramgen\_bandmat\linalg.c(9309): warning C4244: '=': conversion from 'npy_intp' to 'long', possible loss of data
      nnmnkwii\paramgen\_bandmat\linalg.c(9573): warning C4018: '<': signed/unsigned mismatch
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\bin\HostX86\x64\link.exe" /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\libs /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis /LIBPATH:C:\Users\hiden\anaconda3\envs\remdis\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.40.33807\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\x64" /EXPORT:PyInit_linalg build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\linalg.obj /OUT:build\lib.win-amd64-cpython-311\nnmnkwii\paramgen\_bandmat\linalg.cp311-win_amd64.pyd /IMPLIB:build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\linalg.cp311-win_amd64.lib
         Creating library build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\linalg.cp311-win_amd64.lib and object build\temp.win-amd64-cpython-311\Release\nnmnkwii\paramgen\_bandmat\linalg.cp311-win_amd64.exp
      Generating code
      Finished generating code

      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      cimport cython

      cnp.import_array()
      cnp.import_ufunc()

      def fancy_plus_equals(cnp.ndarray[cnp.int_t, ndim=1] target_index_seq,
                                            ^
      ------------------------------------------------------------

      nnmnkwii\paramgen\_bandmat\misc.pyx:16:38: Invalid type.
      Compiling nnmnkwii\paramgen\_bandmat\misc.pyx because it changed.
      [1/1] Cythonizing nnmnkwii\paramgen\_bandmat\misc.pyx
      Traceback (most recent call last):
        File "C:\Users\hiden\anaconda3\envs\remdis\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
          main()
        File "C:\Users\hiden\anaconda3\envs\remdis\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\hiden\anaconda3\envs\remdis\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 251, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\build_meta.py", line 421, in build_wheel
          return self._build_with_temp_dir(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\build_meta.py", line 403, in _build_with_temp_dir
          self.run_setup()
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\build_meta.py", line 503, in run_setup
          super().run_setup(setup_script=setup_script)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 146, in <module>
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\core.py", line 184, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\core.py", line 200, in run_commands
          dist.run_commands()
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\dist.py", line 953, in run_commands
          self.run_command(cmd)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\dist.py", line 950, in run_command
          super().run_command(command)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\dist.py", line 972, in run_command
          cmd_obj.run()
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\command\bdist_wheel.py", line 384, in run
          self.run_command("build")
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\cmd.py", line 316, in run_command
          self.distribution.run_command(command)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\dist.py", line 950, in run_command
          super().run_command(command)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\dist.py", line 972, in run_command
          cmd_obj.run()
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\command\build.py", line 135, in run
          self.run_command(cmd_name)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\cmd.py", line 316, in run_command
          self.distribution.run_command(command)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\dist.py", line 950, in run_command
          super().run_command(command)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\dist.py", line 972, in run_command
          cmd_obj.run()
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\command\build_ext.py", line 359, in run
          self.build_extensions()
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\command\build_ext.py", line 476, in build_extensions
          self._build_extensions_serial()
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\setuptools\_distutils\command\build_ext.py", line 502, in _build_extensions_serial
          self.build_extension(ext)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\Cython\Distutils\build_ext.py", line 130, in build_extension
          new_ext = cythonize(
                    ^^^^^^^^^^
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\Cython\Build\Dependencies.py", line 1154, in cythonize
          cythonize_one(*args)
        File "C:\Users\hiden\AppData\Local\Temp\pip-build-env-95l9qa_b\overlay\Lib\site-packages\Cython\Build\Dependencies.py", line 1321, in cythonize_one
          raise CompileError(None, pyx_file)
      Cython.Compiler.Errors.CompileError: nnmnkwii\paramgen\_bandmat\misc.pyx
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for nnmnkwii
Failed to build nnmnkwii
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (nnmnkwii)
```